### PR TITLE
Check Sold To Presence to Build Order XML

### DIFF
--- a/lib/3pl_central/services.rb
+++ b/lib/3pl_central/services.rb
@@ -57,19 +57,21 @@ module ThreePLCentral
                       xml.tns :FulfillInvShippingAndHandling, data[:fulfillment_info][:fulfill_inv_shipping_and_handling]
                       xml.tns :FulfillInvTax, data[:fulfillment_info][:fulfill_inv_tax]
                     end
-                    xml.tns :SoldTo do |xml|
-                      xml.tns :Name, data[:sold_to][:name]
-                      xml.tns :CompanyName, data[:sold_to][:company_name]
-                      xml.tns :Address do |xml|
-                        xml.tns :Address1, data[:sold_to][:address][:address1]
-                        xml.tns :Address2, data[:sold_to][:address][:address2]
-                        xml.tns :City, data[:sold_to][:address][:city]
-                        xml.tns :State, data[:sold_to][:address][:state]
-                        xml.tns :Zip, data[:sold_to][:address][:zip]
-                        xml.tns :Country, data[:sold_to][:address][:country]
+                    if data[:sold_to]
+                      xml.tns :SoldTo do |xml|
+                        xml.tns :Name, data[:sold_to][:name]
+                        xml.tns :CompanyName, data[:sold_to][:company_name]
+                        xml.tns :Address do |xml|
+                          xml.tns :Address1, data[:sold_to][:address][:address1]
+                          xml.tns :Address2, data[:sold_to][:address][:address2]
+                          xml.tns :City, data[:sold_to][:address][:city]
+                          xml.tns :State, data[:sold_to][:address][:state]
+                          xml.tns :Zip, data[:sold_to][:address][:zip]
+                          xml.tns :Country, data[:sold_to][:address][:country]
+                        end
+                        xml.tns :PhoneNumber1, data[:sold_to][:phone_number1]
+                        xml.tns :EmailAddress1, data[:sold_to][:email_address1]
                       end
-                      xml.tns :PhoneNumber1, data[:sold_to][:phone_number1]
-                      xml.tns :EmailAddress1, data[:sold_to][:email_address1]
                     end
                   end
                 end


### PR DESCRIPTION
When building order XML to create orders in 3PL Central, if the Sold To information is not present, the request dies in Ruby before it ever gets sent via SOAP. The `SoldTo` element (and its children) are not required in the request and this should be omitted if this data is not passed into the method call.