### PR TITLE
Add CustomerID

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ client.get_stock_status(params_for_stock_status)
     c.login               = "customer_login" #configured in 3PL Central -> Customer -> Customer Users
     c.password            = "customer_password" # same as login
     c.default_facility_id = 1 #this might be removed in a later version, and we'll just look for the "Facility ID" on the order or item level.
-    c.user_login_id       = 4 #We had to contact our account manager with 3PL Central to get this information.
+    # c.user_login_id       = 4 #We had to contact our account manager with 3PL Central to get this information.
+    c.customer_id         = 1
+
+    # three_pl_id is for reading, three_pl_key is for writing
+    c.three_pl_id         = "three_pl_id"
   end
 
 ```

--- a/README.md
+++ b/README.md
@@ -75,19 +75,21 @@ ThreePLCentral::Order.create({
       country:"Canada"},
     phone_number1: "999-999-9999",
     email_address1: "test@test.com",
-    shipping_instructions: {
-      carrier: "FedEx",
-      mode: "Ground",
-      shipping_notes: "I need it ASAP!"}
   },
+  shipping_instructions: {
+    carrier: "FedEx",
+    mode: "Ground",
+    shipping_notes: "I need it ASAP!"},
   notes: "More notes!",
   order_line_items: [
-    {
+    # NOTE: This is an array of hashes, each hash only contain one key:
+    # `order_line_item`
+    { order_line_item: {
       sku:"90RND-010101",
       qty:"10",
       fulfillment_sale_price:9.99,
       fulfillment_discount_percentage:10,
-      fulfillment_discount_amount:0.99}
+      fulfillment_discount_amount:0.99}}
   ],
   fulfillment_info:{
     fulfill_inv_shipping_and_handling:9.12,

--- a/README.md
+++ b/README.md
@@ -63,34 +63,36 @@ client.get_stock_status(params_for_stock_status)
 
 ThreePLCentral::Order.create({
   trans_info: {
-    reference_num: "100001",
+    reference_num: "100001",  # required
     expected_date: "2014-11-12",
     earliest_ship_date: "2014-11-12",
     ship_cancel_date:  "2014-11-12"},
   ship_to: {
     name: "Test Test",
-    company_name: "Test Co.",
+    company_name: "Test Co.",  # required
     address:{
-      address1: "Toronto",
+      address1: "Toronto",  # required
       address2:"Ste. 2",
-      city:"1234 Fake St.",
-      state:"ON",
-      zip:"M4B 1B3",
-      country:"Canada"},
+      city:"1234 Fake St.",  # required
+      state:"ON",  # required
+      zip:"M4B 1B3",  # required
+      country:"Canada"  # required
+    },
     phone_number1: "999-999-9999",
     email_address1: "test@test.com",
   },
   shipping_instructions: {
-    carrier: "FedEx",
-    mode: "Ground",
+    carrier: "FedEx",  # required
+    mode: "Ground",  # required
+    billing_code: "Prepaid"  # required
     shipping_notes: "I need it ASAP!"},
   notes: "More notes!",
-  order_line_items: [
+  order_line_items: [  # required at least one
     # NOTE: This is an array of hashes, each hash only contain one key:
     # `order_line_item`
     { order_line_item: {
-      sku:"90RND-010101",
-      qty:"10",
+      SKU:"90RND-010101", # It must be all uppercase, required
+      qty:"10",  # required
       fulfillment_sale_price:9.99,
       fulfillment_discount_percentage:10,
       fulfillment_discount_amount:0.99}}

--- a/lib/3pl_central/base.rb
+++ b/lib/3pl_central/base.rb
@@ -6,7 +6,8 @@ module ThreePLCentral
         "ThreePLKey" => ThreePLCentral.configuration.three_pl_key,
         login: ThreePLCentral.configuration.login,
         password: ThreePLCentral.configuration.password,
-        facility_id: facility_id || ThreePLCentral.configuration.default_facility_id
+        Facility_ID: facility_id || ThreePLCentral.configuration.default_facility_id,
+        Customer_ID: ThreePLCentral.configuration.customer_id
       }}
     end
 
@@ -21,6 +22,6 @@ module ThreePLCentral
     def self.parser
       @parser ||= Nori.new(:convert_tags_to => lambda { |tag| tag.snakecase.to_sym })
     end
-    
+
   end
 end

--- a/lib/3pl_central/client.rb
+++ b/lib/3pl_central/client.rb
@@ -6,6 +6,7 @@ module ThreePLCentral
         c.login        = params[:login]
         c.password     = params[:password]
         c.three_pl_id  = params[:three_pl_id]
+        c.customer_id  = params[:customer_id]
       end
     end
 

--- a/lib/3pl_central/configuration.rb
+++ b/lib/3pl_central/configuration.rb
@@ -7,7 +7,10 @@ module ThreePLCentral
 	end
 
 	def self.client
-		@client ||= Savon.client(wsdl:WSDL_URL, ssl_version: :TLSv1, ssl_verify_mode: :none, log_level: :debug, log: true, pretty_print_xml: true, no_message_tag:true, convert_request_keys_to: :camelcase)
+		@client ||= Savon.client(wsdl:WSDL_URL,
+		  ssl_version: :TLSv1, ssl_verify_mode: :none,
+			log_level: :debug, log: true, pretty_print_xml: true,
+			no_message_tag:true, convert_request_keys_to: :camelcase)
 	end
 
 	def self.configure
@@ -16,14 +19,16 @@ module ThreePLCentral
 	end
 
 	class Configuration
-		attr_accessor :three_pl_key, :login, :password, :default_facility_id, :three_pl_id
+		attr_accessor :three_pl_key, :login, :password, :default_facility_id,
+			:three_pl_id, :customer_id
 
 		def initialize
 			@three_pl_key        = ''
 			@login               = ''
 			@password            = ''
 			@default_facility_id = ''
-			@three_pl_id 			 = ''
+			@three_pl_id 			   = ''
+			@customer_id         = ''
 		end
 	end
 end


### PR DESCRIPTION
We had to add the CustomerID field instead of UserLoginID.

It's odd that the same version of 3PL Central API changed, so please confirm that this update works for you before accepting it just in case we're missing something.